### PR TITLE
remove cdist.so dependency, compile statically into installed module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ EXE=
 all:	dist.so
 
 # building a shared C library libcmean.so
-libcdist.so: cdist.c
-	$(CC) $(CFLAGS) -fPIC -shared cdist.c -o libcdist.so
+#libcdist.so: cdist.c
+#	$(CC) $(CFLAGS) -fPIC -shared cdist.c -o libcdist.so
 
 # building python extension calling a function from shared C library
-dist.so:	cython_dist.pyx libcdist.so setup.py
+dist.so:	cython_dist.pyx setup.py cdist.c
 	python setup.py build_ext --inplace --rpath=.
 
 # running a Python test

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ EXE=
 
 all:	dist.so
 
+install:
+	python setup.py install
+
 # building a shared C library libcmean.so
 #libcdist.so: cdist.c
 #	$(CC) $(CFLAGS) -fPIC -shared cdist.c -o libcdist.so

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,8 @@ from distutils.extension import Extension
 from Cython.Distutils import build_ext
 ext_modules = [
     Extension("dist",
-              ["cython_dist.pyx"],
-              library_dirs=['.'],
-              libraries=["cdist"])  # Unix-like specific
+              ["cython_dist.pyx", 'cdist.c'],
+              library_dirs=['.'])
 ]
 setup(
     name="Demos",


### PR DESCRIPTION
this should let 'python setup.py install' work, and (if you choose to put it on pypi) 'pip install pdist'.